### PR TITLE
Update Uitwerking.md

### DIFF
--- a/Uitwerking.md
+++ b/Uitwerking.md
@@ -125,7 +125,7 @@ Voor de uitwerking van de component gelden de volgende uitgangspunten:
 -   De opslag-component is een intern onderdeel dat alleen via services
     is te benaderen. Het is daarom niet nodig om hiervoor een standaard invulling te
     hanteren. De technische wijze van opslag is verantwoordelijkheid van de
-    uitvoeringspartij die dit invult.
+    uitvoeringspartij die dit invult. (Opm ML) 
 
 **Vereisten**
 


### PR DESCRIPTION
5.2.2:  "Het is daarom niet nodig om hiervoor een standaard invulling te hanteren. De technische wijze van opslag is verantwoordelijkheid van de uitvoeringspartij die dit invult." Bij de WOZ hebben we veel "last" gehad van een eigen mechanisme voor de opslag. Het opslagmodel was daar "generiek" en leverde op een bepaald moment problemen op die alleen met heel veel investering konden worden opgelost. Ik weet niet of je dit zo hard moet neerzetten.